### PR TITLE
ci: change linux build to use gcc10

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,0 @@
-# These are supported funding model platforms
-
-github: lefticus
-patreon: lefticus

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -1,5 +1,4 @@
 name: CMake
-
 on:
   pull_request:
   push:
@@ -23,20 +22,13 @@ defaults:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        os: ['ubuntu-latest']
         include:
         - os: ubuntu-latest
           ENABLE_COVERAGE: ON
-        - os: windows-latest
-          # Windows works differently
-          ENABLE_COVERAGE: OFF
-        - os: macos-latest
-          ENABLE_COVERAGE: ON
-
 
     steps:
     - uses: actions/checkout@v2
@@ -63,35 +55,29 @@ jobs:
           echo "Ubuntu - Fix Conan Path"
           sudo update-alternatives --install /usr/bin/conan conan /home/runner/.local/bin/conan 10
           sudo update-alternatives --config conan
-        elif [ "$RUNNER_OS" == "Windows" ]; then
-          echo "Using chocolatey to install OpenCppCoverage"
-          choco install opencppcoverage
-          # Add to Path
-          echo "C:/Program Files/OpenCppCoverage" >> $GITHUB_PATH
         fi;
 
     - name: Configure CMake
+      env:
+        CC: gcc-10
+        CXX: g++-10
       run: |
           cmake -S . -B ./build -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DENABLE_COVERAGE:BOOL=${{ matrix.ENABLE_COVERAGE }}
 
     - name: Build
       # Execute the build.  You can specify a specific target with "--target <NAME>"
+      env:
+        CC: gcc-10
+        CXX: g++-10
       run: cmake --build ./build --config $BUILD_TYPE
 
     - name: Unix - Test and coverage
-      if: runner.os != 'Windows'
       working-directory: ./build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: |
           ctest -C $BUILD_TYPE
           gcovr -j $(nproc) --delete --root ../ --print-summary --xml-pretty --xml coverage.xml .
-
-    - name: Windows - Test and coverage
-      if: runner.os == 'Windows'
-      working-directory: ./build
-      run: |
-        OpenCppCoverage.exe --sources cpp_starter_project --export_type cobertura:coverage.xml --cover_children -- ctest -C $BUILD_TYPE
 
     - name: Publish to codecov
       uses: codecov/codecov-action@v2


### PR DESCRIPTION
macos and windows builds were removed also, one could
profit more by adding a new build step to build with clang
instead of targetting 3 different platforms when one
only wants to build a linux desktop app.